### PR TITLE
fix role name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Create symlink for role
           command: >
             mkdir -p ~/.ansible/roles
-              ln -s $(pwd) ~/.ansible/roles/${CIRCLE_PROJECT_REPONAME}
+              ln -s $(pwd) ~/.ansible/roles/${CIRCLE_PROJECT_REPONAME##*-}
       - run:
           name: Syntax check playbook
           command: pwd; ls; ansible-playbook --syntax-check tests/test.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - grace-ansible-template
+    - template


### PR DESCRIPTION
- fixes `[E106] Role name grace-ansible-template does not match ``^[a-z][a-z0-9_]+$`` pattern`